### PR TITLE
Test stdin tty ragardless of shell type

### DIFF
--- a/fsh
+++ b/fsh
@@ -233,10 +233,7 @@ fsh() {
   }
 
   get_choices() {
-    if [ "$terminal" = zsh ] && [ ! -t 0 ]
-    then
-      choices=$(cat </dev/stdin)
-    elif [ "$terminal" != zsh ] && read -r -t0
+    if [ ! -t 0 ]
     then
       choices=$(cat </dev/stdin)
     fi


### PR DESCRIPTION
For zsh stdin is read when it is not tty. However, for bash there is a test that stdin contains data. This check will fail if some command piped to fsh and requires some time to prepare output data. E.g. it will fail with `ls / | ./fsh`. This fix makes behaviour consistent and fsh checks that stdin is tty for any shell type.